### PR TITLE
Generalize race and inParallel

### DIFF
--- a/src/Yoga/Om.purs
+++ b/src/Yoga/Om.purs
@@ -138,14 +138,14 @@ error
   -> OneOfTheseErrors errors
 error = singletonRecordToVariant
 
--- | Run multiple `Om` computations in parallel, and return the fastest
+-- | Run multiple computations in parallel, and return the fastest
 -- | To collect all results, use `inParallel` instead
-race :: forall ctx e a. Array (Om ctx e a) -> Om ctx e a
+race :: forall f m a. Parallel f m => Alternative f => Array (m a) -> m a
 race = parOneOf
 
--- | Run multiple `Om`s in parallel, and collect all results
+-- | Run multiple computations in parallel, and collect all results
 -- | To only take the fastest result, use `race`
-inParallel :: forall ctx e a. Array (Om ctx e a) -> Om ctx e (Array a)
+inParallel :: forall f m a. Parallel f m => Applicative f => Array (m a) -> m (Array a)
 inParallel = parSequence
 
 delay :: forall m d. MonadAff m => Duration d => d -> m Unit


### PR DESCRIPTION
## Summary
- Generalize `race` and `inParallel` to work with any `Parallel` monad, not just `Om`
- This allows them to be used with `OmLayer` (and any other monad with a `Parallel` instance)

## Test plan
- [x] All 49 existing tests pass
- [x] No API breakage — existing `Om` call sites infer the same types

🤖 Generated with [Claude Code](https://claude.com/claude-code)